### PR TITLE
Aevents

### DIFF
--- a/frontend/src/actions/session_actions.js
+++ b/frontend/src/actions/session_actions.js
@@ -4,6 +4,7 @@ import jwt_decode from 'jwt-decode';
 export const RECEIVE_CURRENT_USER = "RECEIVE_CURRENT_USER";
 export const RECEIVE_SESSION_ERRORS = "RECEIVE_SESSION_ERRORS";
 export const RECEIVE_USER_LOGOUT = "RECEIVE_USER_LOGOUT";
+export const RECIEVE_CURRENT_USER_EVENTS = "RECIEVE_CURRENT_USER_EVENTS"
 // export const RECEIVE_USER_SIGN_IN = "RECEIVE_USER_SIGN_IN";
 
 // We'll dispatch this when our user signs in
@@ -27,6 +28,12 @@ export const receiveErrors = errors => ({
 export const logoutUser = () => ({
   type: RECEIVE_USER_LOGOUT
 });
+
+// Receive a Current User's events
+const currentUserEvents = (user) => ({
+  type: RECIEVE_CURRENT_USER_EVENTS,
+  user
+})
 
 // Upon signup, dispatch the approporiate action depending on which type of response we receieve from the backend
 // if we sign up successfuly and insert a new user into the DB,
@@ -68,3 +75,9 @@ export const logout = () => dispatch => {
   APIUtil.setAuthToken(false)
   dispatch(logoutUser())
 };
+
+
+export const userEvents = (userId) => dispatch => {
+  APIUtil.userEvents(userId)
+    .then((user) => dispatch(currentUserEvents(user)))
+}

--- a/frontend/src/actions/thread_actions.js
+++ b/frontend/src/actions/thread_actions.js
@@ -4,7 +4,6 @@ export const RECEIVE_THREAD = "RECEIVE_THREAD";
 export const RECEIVE_NEW_THREAD = "RECEIVE_NEW_THREAD";
 export const REMOVE_THREAD = "REMOVE_THREAD";
 export const RECEIVE_THREAD_ERRORS = "RECEIVE_THREAD_ERRORS";
-export const REMOVE_THREAD_ERRORS = "REMOVE_THREAD_ERRORS";
 
 export const receiveThread = (thread) => ({
   type: RECEIVE_THREAD,
@@ -26,9 +25,6 @@ const receiveThreadErrors = (errors) => ({
   errors
 });
 
-const removeThreadErrors = (errors) => ({
-  type: REMOVE_THREAD_ERRORS
-});
 
 export const createThread = (thread) => dispatch => {
   ThreadApiUtil.makeThread(thread)

--- a/frontend/src/actions/thread_actions.js
+++ b/frontend/src/actions/thread_actions.js
@@ -50,13 +50,11 @@ export const updateThread = (thread) => dispatch => {
 export const createComment = (threadId, comment) => dispatch => (
   ThreadApiUtil.makeComment(threadId, comment)
     .then(thread => dispatch(receiveThread(thread)))
-    .catch(err => dispatch(receiveCommentErrors(err.response.data)))
 );
 
 export const updateComment = (threadId, commentId, comment) => dispatch => (
   ThreadApiUtil.editComment(threadId, commentId, comment)
     .then(thread => dispatch(receiveThread(thread)))
-    .catch(err => dispatch(receiveCommentErrors(err.response.data)))
 );
 
 export const removeComment = (threadId, commentId) => dispatch => (

--- a/frontend/src/components/event_form/event_form.jsx
+++ b/frontend/src/components/event_form/event_form.jsx
@@ -36,8 +36,6 @@ class EventForm extends React.Component{
   handleSubmit(e) {
     e.preventDefault();
     let that = this; 
-
-    console.log(this.state);
     // Create new Event and then push to the Event's page.
     this.props.action(this.state).then(function(event){
       return that.props.history.push(`/events`)

--- a/frontend/src/components/event_index/event_index.jsx
+++ b/frontend/src/components/event_index/event_index.jsx
@@ -5,6 +5,7 @@ import EventIndexItem from "./event_index_item";
 class EventIndex extends React.Component{
   componentDidMount(){
     this.props.fetchEvents();
+    this.props.getUserEvents(this.props.user);
   }
 
   renderEventBar() {

--- a/frontend/src/components/event_index/event_index_container.js
+++ b/frontend/src/components/event_index/event_index_container.js
@@ -1,6 +1,7 @@
 import { connect } from "react-redux";
 import EventIndex from "./event_index";
 import { fetchEvents } from "../../actions/event_actions";
+import { userEvents } from "../../actions/session_actions"
 
 const mSTP = state => ({
   allEvents: Object.values(state.events.all),
@@ -8,7 +9,9 @@ const mSTP = state => ({
 });
 
 const mDTP = dispatch => ({
-  fetchEvents: () => dispatch(fetchEvents())
+  fetchEvents: () => dispatch(fetchEvents()),
+  getUserEvents: (userId) => dispatch(userEvents(userId))
+
 });
 
 export default connect(mSTP, mDTP)(EventIndex);

--- a/frontend/src/components/profile/profile.jsx
+++ b/frontend/src/components/profile/profile.jsx
@@ -42,7 +42,26 @@ class Profile extends React.Component {
       <ul id="profile-self-event-list">
         {this.props.allEvents?.map(event => {
           if (event.owner === this.props.currentUser.id) {
+            console.log(event)
             return <EventIndexItem key={event._id} event={event} />
+          }
+        })}
+      </ul>
+    )
+  }
+
+  renderNonOwnEvents(){
+    if(Object.values(this.props.allEvents).length === 0){
+      return null
+    }
+
+
+
+    return (
+      <ul id="profile-self-event-list">
+        {this.props.allEvents?.map(event => {
+          if(event.owner !== this.props.currentUser.id){
+            return <eventIndexItem key={event._id} event = {event}/>
           }
         })}
       </ul>

--- a/frontend/src/components/profile/profile.jsx
+++ b/frontend/src/components/profile/profile.jsx
@@ -11,7 +11,8 @@ class Profile extends React.Component {
   }
 
   componentDidMount(){
-    this.props.fetchEvents();
+    // this.props.fetchEvents();
+    this.props.getUserEvents(this.props.currentUser.id);
   }
 
   renderEventBar() {
@@ -29,18 +30,25 @@ class Profile extends React.Component {
         </div>
 
         {this.renderOwnEvents()}
+        <br>
+        </br>
+        <div> 
+        <div id="profile-self-title">
+          Events you are a part of:
+          </div>
+        {this.renderNonOwnEvents()}
+        </div>
       </div>
     )
   }
 
   renderOwnEvents() {
-    if(Object.values(this.props.allEvents).length === 0) {
+    if(Object.values(this.props.userEvents).length === 0) {
       return null
     }
-
     return (
       <ul id="profile-self-event-list">
-        {this.props.allEvents?.map(event => {
+        {this.props.userEvents?.map(event => {
           return event.owner === this.props.currentUser.id
             ? <EventIndexItem key={event._id} event={event} />
             : null
@@ -50,18 +58,14 @@ class Profile extends React.Component {
   }
 
   renderNonOwnEvents(){
-    if(Object.values(this.props.allEvents).length === 0){
+    if(Object.values(this.props.userEvents).length === 0){
       return null
     }
-
-
-
     return (
       <ul id="profile-self-event-list">
-        {this.props.allEvents?.map(event => {
-          if(event.owner !== this.props.currentUser.id){
-            return <eventIndexItem key={event._id} event = {event}/>
-          }
+        {this.props.userEvents?.map(event => {
+          return event.owner !== this.props.currentUser.id
+          ? <EventIndexItem key={event._id} event = {event}/> : null
         })}
       </ul>
     )

--- a/frontend/src/components/profile/profile_container.js
+++ b/frontend/src/components/profile/profile_container.js
@@ -1,17 +1,20 @@
 import { connect } from 'react-redux';
 import Profile from './profile';
 import { fetchEvents } from "../../actions/event_actions";
+import { userEvents } from "../../actions/session_actions"
 
 const mapStateToProps = (state) => {
   return {
     allEvents: Object.values(state.events.all),
+    userEvents: Object.values(state.events.user),
     currentUser: state.session.user
   };
 };
 
 const mapDispatchToProps = dispatch => {
   return {
-    fetchEvents: () => dispatch(fetchEvents())
+    fetchEvents: () => dispatch(fetchEvents()),
+    getUserEvents: (userId) => dispatch(userEvents(userId))
   };
 };
 

--- a/frontend/src/reducers/events_reducer.js
+++ b/frontend/src/reducers/events_reducer.js
@@ -1,4 +1,5 @@
-import { RECEIVE_EVENTS, RECEIVE_EVENT, REMOVE_EVENT } from "../actions/event_actions"
+import { RECEIVE_EVENTS, RECEIVE_EVENT, REMOVE_EVENT} from "../actions/event_actions"
+import { RECIEVE_CURRENT_USER_EVENTS } from "../actions/session_actions"
 
 const eventReducer = (state = { all: {}, user: {}, new: undefined }, action) => {
   Object.freeze(state)
@@ -17,6 +18,9 @@ const eventReducer = (state = { all: {}, user: {}, new: undefined }, action) => 
     case REMOVE_EVENT:
       delete newState[action.eventId]
       return newState
+    case RECIEVE_CURRENT_USER_EVENTS:
+      newState.user = Object.assign({}, action.user.data.events)
+      return newState;
     default:
       return state;
   };

--- a/frontend/src/reducers/session_api_reducer.js
+++ b/frontend/src/reducers/session_api_reducer.js
@@ -20,11 +20,6 @@ const sessionApiReducer = (state = initialState, action) => {
         isAuthenticated: false,
         user: undefined
       };
-    // case RECEIVE_USER_SIGN_IN:
-    //   return {
-    //     ...state,
-    //     isSignedIn: true
-    //   }
     default:
       return state;
   }

--- a/frontend/src/reducers/threads_errors_reducer.js
+++ b/frontend/src/reducers/threads_errors_reducer.js
@@ -1,4 +1,4 @@
-import { RECEIVE_THREAD, RECEIVE_NEW_THREAD, RECEIVE_THREAD_ERRORS, REMOVE_THREAD_ERRORS } from "../actions/thread_actions";
+import { RECEIVE_THREAD, RECEIVE_NEW_THREAD, RECEIVE_THREAD_ERRORS} from "../actions/thread_actions";
 
 const _nullErrors = [];
 
@@ -13,8 +13,6 @@ const ThreadsErrorsReducer = (state = _nullErrors, action) => {
       return _nullErrors;
     case RECEIVE_THREAD:
       return _nullErrors;
-    case REMOVE_THREAD_ERRORS:
-      return [];
     default:
       return state;
   }

--- a/frontend/src/util/session_api_util.js
+++ b/frontend/src/util/session_api_util.js
@@ -17,3 +17,7 @@ export const signup = (userData) => {
 export const login = (userData) => {
   return axios.post('/api/users/login', userData);
 };
+
+export const userEvents = (userId) => {
+  return axios.get(`/api/users/${userId}`)
+}

--- a/routes/api/users.js
+++ b/routes/api/users.js
@@ -109,7 +109,7 @@ router.post("/login", (req, res) => {
   });
 });
 
-// GET route for an Indiviudal User - gives back events, name, description, PointsofInterest
+// GET route for an Indiviudal User of non owned events
 router.get('/:id',
   passport.authenticate('jwt', {session: false}),
   (req, res) => {
@@ -117,7 +117,6 @@ router.get('/:id',
     .populate({
     path:"events",
     model: "Event",
-    select: "name description PointsOfInterest"
   })
     .then( user => {res.json(user)})
     .catch(err => res.status(404).json({ noUserFound: "No user found with that ID"}))


### PR DESCRIPTION
I create a new thunk action creator that sends a request to the backend and then ends with putting all of a users events into the events.user slice of state. There is some duplication of data as an event can live both in events.all and event.user, but it makes for easier grabbing a users events both on the event index page and the user index page. Furthermore, if I have time I can probably change  it so that All events can take in an operational parameter where it filters itself based on the current user, on ownership and membership (but that is bonus).